### PR TITLE
feat: add start-api to mimic API Gateway integration

### DIFF
--- a/modules/byol-cli/README.md
+++ b/modules/byol-cli/README.md
@@ -29,6 +29,17 @@ byol start-lambda [-p PORT] [-s | --silent]
 
 With this server running you can call your Lambdas using the [aws-sdk](https://github.com/aws/aws-sdk-js).
 
+### start-api
+
+Starts a server mimicing API Gateway in proxy mode. Similar to `sam local start-api` you can call endpoints defined
+in your template file. Currently, only event sources on the function resource `AWS::Serverless::Function` are supported.
+
+```shell script
+byol start-api [-p PORT] [-s | --silent]
+```
+
+With the server running, call your API over HTTP as usual.
+
 ### invoke
 
 Invoke a function as defined in your `template.yml`. This is a replacement for `sam local invoke`.

--- a/modules/byol-cli/src/commands/startApi.js/index.js
+++ b/modules/byol-cli/src/commands/startApi.js/index.js
@@ -1,0 +1,22 @@
+const { handleGlobalOptions } = require('../../handleGlobalOptions');
+const { startApiServer } = require('./startApiServer');
+
+const command = ['start-api'];
+const desc = 'Start a local api server';
+const builder = yargs =>
+    yargs.option('port', {
+        alias: 'p',
+        default: 3000,
+    });
+const handler = async ({ port, ...globalOptions }) => {
+    handleGlobalOptions(globalOptions);
+
+    startApiServer(port);
+};
+
+module.exports = {
+    command,
+    desc,
+    builder,
+    handler,
+};

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -19,9 +19,8 @@ app.all('*', (req, res) => {
             .then((result) => {
                 res.send(result);
             })
-            .catch((err) => {
+            .catch(() => {
                 res.status(500);
-                res.send(err);
                 res.end();
             });
     });

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -29,7 +29,6 @@ app.all('*', (req, res) => {
                     Object.keys(result.headers).forEach((headerKey) => {
                         const headerValue = result.headers[headerKey];
 
-
                         multiValueHeadersMap.set(headerKey, new Set([headerValue]));
                     });
                 }

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -12,10 +12,7 @@ app.all('*', (req, res) => {
     });
 
     req.on('end', () => {
-        const httpMethod = req.method;
-        const path = req.url;
-
-        invokeApi(httpMethod, path, body)
+        invokeApi(req.method, req.url, req.rawHeaders, body)
             .catch(() => {
                 // Intentionally left blank, ignore error and have then return a 502.
             })

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const { invokeApi } = require('@swydo/byol');
+const debug = require('debug')('byol:server');
+
+const app = express();
+
+app.all('*', (req, res) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+        body += chunk;
+    });
+
+    req.on('end', () => {
+        const httpMethod = req.method;
+        const path = req.url;
+
+        invokeApi(httpMethod, path, body)
+            .then((result) => {
+                res.send(result);
+            })
+            .catch((err) => {
+                res.status(500);
+                res.send(err);
+                res.end();
+            });
+    });
+});
+
+function startApiServer(port) {
+    app.listen(port);
+
+    debug('Listening on port', port);
+}
+
+module.exports = {
+    startApiServer,
+};

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -19,6 +19,8 @@ app.all('*', (req, res) => {
             .then((result) => {
                 if (!result) {
                     res.status(502);
+                    res.end();
+                    return;
                 }
 
                 const multiValueHeadersMap = new Map();

--- a/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
+++ b/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
@@ -20,9 +20,8 @@ app.post('/2015-03-31/functions/:functionName/invocations', (req, res) => {
             .then((result) => {
                 res.send(result);
             })
-            .catch((err) => {
+            .catch(() => {
                 res.status(500);
-                res.send(err);
                 res.end();
             });
     });

--- a/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
+++ b/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
@@ -20,8 +20,9 @@ app.post('/2015-03-31/functions/:functionName/invocations', (req, res) => {
             .then((result) => {
                 res.send(result);
             })
-            .catch(() => {
+            .catch((err) => {
                 res.status(500);
+                res.send(err);
                 res.end();
             });
     });

--- a/modules/byol-cli/src/index.js
+++ b/modules/byol-cli/src/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const yargs = require('yargs');
+const startApiCommand = require('./commands/startApi.js');
 const startLambdaCommand = require('./commands/startLambda');
 const invokeCommand = require('./commands/invoke');
 
@@ -11,6 +12,7 @@ yargs
         type: 'boolean',
         default: false,
     })
+    .command(startApiCommand)
     .command(startLambdaCommand)
     .command(invokeCommand)
     .argv;

--- a/modules/byol/package-lock.json
+++ b/modules/byol/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@swydo/byol",
-	"version": "1.0.0",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9,7 +9,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"debug": {
@@ -17,7 +17,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "^2.1.1"
 			}
 		},
 		"esprima": {
@@ -30,13 +30,32 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
+		"http-errors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+			"integrity": "sha1-bAJC3qaz33r9oVPHEImzHG6Cqr8=",
+			"requires": {
+				"inherits": "2.0.1",
+				"statuses": ">= 1.2.1 < 2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+			"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
 		"js-yaml": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"ms": {
@@ -44,17 +63,39 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"path-match": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/path-match/-/path-match-1.2.4.tgz",
+			"integrity": "sha1-pidH88fgwlFHYml/JEQ1hbCRAOo=",
+			"requires": {
+				"http-errors": "~1.4.0",
+				"path-to-regexp": "^1.0.0"
+			}
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"supports-color": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.0.0.tgz",
 			"integrity": "sha512-WRt32iTpYEZWYOpcetGm0NPeSvaebccx7hhS/5M6sAiqnhedtFCHFxkjzZlJvFNCPowiKSFGiZk5USQDFy83vQ==",
 			"requires": {
-				"has-flag": "4.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"uuid": {
@@ -67,7 +108,7 @@
 			"resolved": "https://registry.npmjs.org/yaml-cfn/-/yaml-cfn-0.2.2.tgz",
 			"integrity": "sha512-TwPBRIa8Zde25Rl3KHyOlNjHGdJaXRdlS6iSVFDSFp2/ixz/+kHUd3o1/b4vAv1isodH+IUjem3f+AvQYPvNtQ==",
 			"requires": {
-				"js-yaml": "3.13.1"
+				"js-yaml": "^3.10.0"
 			}
 		}
 	}

--- a/modules/byol/package.json
+++ b/modules/byol/package.json
@@ -9,6 +9,7 @@
 	},
 	"dependencies": {
 		"debug": "^4.1.1",
+		"path-match": "^1.2.4",
 		"supports-color": "^7.0.0",
 		"uuid": "^3.3.2",
 		"yaml-cfn": "^0.2.2"

--- a/modules/byol/src/getTemplate.js
+++ b/modules/byol/src/getTemplate.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const { yamlParse } = require('yaml-cfn');
+
+function getTemplate(templatePath = path.join(process.cwd(), 'template.yml')) {
+    const templateFileExists = fs.existsSync(templatePath);
+
+    if (!templateFileExists) {
+        throw new Error('TEMPLATE_FILE_NOT_FOUND');
+    }
+
+    const templateString = fs.readFileSync(templatePath, { encoding: 'utf8' });
+
+    return yamlParse(templateString);
+}
+
+module.exports = {
+    getTemplate,
+};

--- a/modules/byol/src/index.js
+++ b/modules/byol/src/index.js
@@ -1,7 +1,9 @@
+const { invokeApi } = require('./invokeApi');
 const { invokeFunction } = require('./invokeFunction');
 const { invokeHandler } = require('./invokeHandler');
 
 module.exports = {
+    invokeApi,
     invokeFunction,
     invokeHandler,
 };

--- a/modules/byol/src/invokeApi.js
+++ b/modules/byol/src/invokeApi.js
@@ -24,7 +24,7 @@ function getApiEvents(resource) {
 }
 
 function createRoute(awsPath) {
-    const expressPath = awsPath.replace(/({.*})/g, (match) => {
+    const expressPath = awsPath.replace(/({[a-zA-Z0-9]*})/g, (match) => {
         const parameterName = match.substring(1, match.length - 1);
 
         return `:${parameterName}`;

--- a/modules/byol/src/invokeApi.js
+++ b/modules/byol/src/invokeApi.js
@@ -55,7 +55,7 @@ function invokeApi(httpMethod, httpPath, body, {
     ));
 
     if (!match) {
-        throw new Error('API_NOT_FOUND');
+        return { statusCode: 404 };
     }
 
     const event = {

--- a/modules/byol/src/invokeApi.js
+++ b/modules/byol/src/invokeApi.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const { getTemplate } = require('./getTemplate');
+const { invokeFunction } = require('./invokeFunction');
+
+const FUNCTION_RESOURCE_TYPE = 'AWS::Serverless::Function';
+const API_EVENT_TYPE = 'Api';
+
+function getApiEvents(resource) {
+    if (!resource.Properties || !resource.Properties.Events) {
+        return [];
+    }
+
+    const events = resource.Properties.Events;
+    const eventKeys = Object.keys(events);
+    const apiEventKeys = eventKeys.filter(key => events[key].Type === API_EVENT_TYPE);
+
+    return apiEventKeys.map(key => events[key]);
+}
+
+function getApiMapping(resources) {
+    const resourceKeys = Object.keys(resources);
+    const functionResourceKeys = resourceKeys.filter(key => resources[key].Type === FUNCTION_RESOURCE_TYPE);
+
+    return functionResourceKeys.map((functionResourceKey) => {
+        const functionResource = resources[functionResourceKey];
+        const apiEvents = getApiEvents(functionResource);
+
+        const listeners = apiEvents.map(event => ({
+            httpMethod: event.Properties.Method.toUpperCase(),
+            path: event.Properties.Path,
+        }));
+
+        return {
+            functionName: functionResourceKey,
+            functionResource,
+            listeners,
+        };
+    });
+}
+
+function invokeApi(httpMethod, httpPath, body, {
+    templatePath,
+    envPath,
+} = {}) {
+    const template = getTemplate(templatePath);
+
+    if (!template.Resources) {
+        throw new Error('TEMPLATE_RESOURCES_MISSING');
+    }
+
+    const apiMapping = getApiMapping(template.Resources);
+
+    const match = apiMapping.find(mapping => (
+        mapping.listeners.some(listener => listener.httpMethod === httpMethod && listener.path === httpPath)
+    ));
+
+    if (!match) {
+        throw new Error('API_NOT_FOUND');
+    }
+
+    const event = {
+        httpMethod,
+        httpPath,
+        body,
+    };
+    return invokeFunction(match.functionName, event, { templatePath, envPath });
+}
+
+module.exports = {
+    invokeApi,
+};

--- a/modules/byol/src/invokeFunction.js
+++ b/modules/byol/src/invokeFunction.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
-const { yamlParse } = require('yaml-cfn');
-const { invokeHandler } = require('./invokeHandler');
 const uuidv4 = require('uuid/v4');
 const rawDebug = require('debug');
+const { invokeHandler } = require('./invokeHandler');
+const { getTemplate } = require('./getTemplate');
 
 function generateRequestId() {
     return uuidv4();
@@ -11,18 +11,6 @@ function generateRequestId() {
 
 function getDebug(requestId) {
     return rawDebug(`byol:invoke:${requestId}`);
-}
-
-function getTemplate(templatePath) {
-    const templateFileExists = fs.existsSync(templatePath);
-
-    if (!templateFileExists) {
-        throw new Error('TEMPLATE_FILE_NOT_FOUND');
-    }
-
-    const templateString = fs.readFileSync(templatePath, { encoding: 'utf8' });
-
-    return yamlParse(templateString);
 }
 
 function getFunctionResource(templatePath, functionName) {


### PR DESCRIPTION
Now this is (very) incomplete, but a decent starting point given our own use cases. Some limitations:

TODO:
- [x] The event is incomplete (no headers, query params).
- [x] It's not possible to match resources with path parameters.
- [x] The response format doesn't match API Gateway.

Out of scope:
- Routes defined "the other way around" from api gateway resource to function resource.