### PR TITLE
feat: use workerpool to invoke handlers in long-lived workers

### DIFF
--- a/modules/byol-cli/README.md
+++ b/modules/byol-cli/README.md
@@ -23,8 +23,8 @@ Start an AWS-compatible Lambda server capable of running the functions defined i
 replacement for `sam local start-lambda`.
 
 ```shell script
-byol start [-p PORT] [-s | --silent]
-byol start-lambda [-p PORT] [-s | --silent]
+byol start [-p PORT] [-s | --silent] [--keep-alive]
+byol start-lambda [-p PORT] [-s | --silent] [--keep-alive]
 ```
 
 With this server running you can call your Lambdas using the [aws-sdk](https://github.com/aws/aws-sdk-js).
@@ -35,7 +35,7 @@ Starts a server mimicing API Gateway in proxy mode. Similar to `sam local start-
 in your template file. Currently, only event sources on the function resource `AWS::Serverless::Function` are supported.
 
 ```shell script
-byol start-api [-p PORT] [-s | --silent]
+byol start-api [-p PORT] [-s | --silent] [--keep-alive]
 ```
 
 With the server running, call your API over HTTP as usual.

--- a/modules/byol-cli/src/commands/startApi.js/index.js
+++ b/modules/byol-cli/src/commands/startApi.js/index.js
@@ -3,14 +3,16 @@ const { startApiServer } = require('./startApiServer');
 
 const command = ['start-api'];
 const desc = 'Start a local api server';
-const builder = (yargs) => yargs.option('port', {
-    alias: 'p',
-    default: 3000,
-});
-const handler = async ({ port, ...globalOptions }) => {
+const builder = (yargs) => yargs
+    .option('port', {
+        alias: 'p',
+        default: 3000,
+    })
+    .option('keep-alive');
+const handler = async ({ port, keepAlive, ...globalOptions }) => {
     handleGlobalOptions(globalOptions);
 
-    startApiServer(port);
+    startApiServer(port, { keepAlive });
 };
 
 module.exports = {

--- a/modules/byol-cli/src/commands/startApi.js/startApiServer.js
+++ b/modules/byol-cli/src/commands/startApi.js/startApiServer.js
@@ -2,68 +2,68 @@ const express = require('express');
 const { invokeApi } = require('@swydo/byol');
 const debug = require('debug')('byol:server');
 
-const app = express();
+function startApiServer(port, { keepAlive }) {
+    const app = express();
 
-app.all('*', (req, res) => {
-    let body = '';
+    app.all('*', (req, res) => {
+        let body = '';
 
-    req.on('data', (chunk) => {
-        body += chunk;
-    });
+        req.on('data', (chunk) => {
+            body += chunk;
+        });
 
-    req.on('end', () => {
-        invokeApi(req.method, req.url, req.rawHeaders, body)
-            .catch(() => {
-                // Intentionally left blank, ignore error and have then return a 502.
-            })
-            .then((result) => {
-                if (!result) {
-                    res.status(502);
-                    res.end();
-                    return;
-                }
-
-                const multiValueHeadersMap = new Map();
-
-                if (result.headers) {
-                    Object.keys(result.headers).forEach((headerKey) => {
-                        const headerValue = result.headers[headerKey];
-
-                        multiValueHeadersMap.set(headerKey, new Set([headerValue]));
-                    });
-                }
-
-                if (result.multiValueHeaders) {
-                    Object.keys(result.multiValueHeaders).forEach((headerKey) => {
-                        const headerValues = result.multiValueHeaders[headerKey];
-
-                        const valuesSet = multiValueHeadersMap.get(headerKey) || new Set();
-                        headerValues.forEach((value) => valuesSet.add(value));
-
-                        multiValueHeadersMap.set(headerKey, valuesSet);
-                    });
-                }
-
-                res.status(result.statusCode);
-                multiValueHeadersMap.forEach((valuesSet, key) => {
-                    const values = Array.from(valuesSet);
-
-                    if (key.toLowerCase() === 'content-type') {
-                        res.set(key, values[0]);
-                    } else {
-                        res.set(key, values);
+        req.on('end', () => {
+            invokeApi(req.method, req.url, req.rawHeaders, body, { keepAlive })
+                .catch(() => {
+                    // Intentionally left blank, ignore error and have then return a 502.
+                })
+                .then((result) => {
+                    if (!result) {
+                        res.status(502);
+                        res.end();
+                        return;
                     }
-                });
-                res.send(result.body);
-            })
-            .catch(() => {
-                res.status(500);
-                res.end();
-            });
-    });
-});
 
-function startApiServer(port) {
+                    const multiValueHeadersMap = new Map();
+
+                    if (result.headers) {
+                        Object.keys(result.headers).forEach((headerKey) => {
+                            const headerValue = result.headers[headerKey];
+
+                            multiValueHeadersMap.set(headerKey, new Set([headerValue]));
+                        });
+                    }
+
+                    if (result.multiValueHeaders) {
+                        Object.keys(result.multiValueHeaders).forEach((headerKey) => {
+                            const headerValues = result.multiValueHeaders[headerKey];
+
+                            const valuesSet = multiValueHeadersMap.get(headerKey) || new Set();
+                            headerValues.forEach((value) => valuesSet.add(value));
+
+                            multiValueHeadersMap.set(headerKey, valuesSet);
+                        });
+                    }
+
+                    res.status(result.statusCode);
+                    multiValueHeadersMap.forEach((valuesSet, key) => {
+                        const values = Array.from(valuesSet);
+
+                        if (key.toLowerCase() === 'content-type') {
+                            res.set(key, values[0]);
+                        } else {
+                            res.set(key, values);
+                        }
+                    });
+                    res.send(result.body);
+                })
+                .catch(() => {
+                    res.status(500);
+                    res.end();
+                });
+        });
+    });
+
     app.listen(port);
 
     debug('Listening on port', port);

--- a/modules/byol-cli/src/commands/startLambda/index.js
+++ b/modules/byol-cli/src/commands/startLambda/index.js
@@ -1,16 +1,18 @@
-const { startLambdaServer } = require('./startLambdaServer');
 const { handleGlobalOptions } = require('../../handleGlobalOptions');
+const { startLambdaServer } = require('./startLambdaServer');
 
 const command = ['start', 'start-lambda'];
 const desc = 'Start a local lambda server';
-const builder = (yargs) => yargs.option('port', {
-    alias: 'p',
-    default: 3000,
-});
-const handler = async ({ port, ...globalOptions }) => {
+const builder = (yargs) => yargs
+    .option('port', {
+        alias: 'p',
+        default: 3000,
+    })
+    .option('keep-alive');
+const handler = async ({ port, keepAlive, ...globalOptions }) => {
     handleGlobalOptions(globalOptions);
 
-    startLambdaServer(port);
+    startLambdaServer(port, { keepAlive });
 };
 
 module.exports = {

--- a/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
+++ b/modules/byol-cli/src/commands/startLambda/startLambdaServer.js
@@ -2,32 +2,32 @@ const express = require('express');
 const { invokeFunction } = require('@swydo/byol');
 const debug = require('debug')('byol:server');
 
-const app = express();
+function startLambdaServer(port, { keepAlive }) {
+    const app = express();
 
-app.post('/2015-03-31/functions/:functionName/invocations', (req, res) => {
-    const { functionName } = req.params;
+    app.post('/2015-03-31/functions/:functionName/invocations', (req, res) => {
+        const { functionName } = req.params;
 
-    let eventString = '';
+        let eventString = '';
 
-    req.on('data', (chunk) => {
-        eventString += chunk;
+        req.on('data', (chunk) => {
+            eventString += chunk;
+        });
+
+        req.on('end', () => {
+            const event = eventString ? JSON.parse(eventString) : {};
+
+            invokeFunction(functionName, event, { keepAlive })
+                .then((result) => {
+                    res.send(result);
+                })
+                .catch(() => {
+                    res.status(500);
+                    res.end();
+                });
+        });
     });
 
-    req.on('end', () => {
-        const event = eventString ? JSON.parse(eventString) : {};
-
-        invokeFunction(functionName, event)
-            .then((result) => {
-                res.send(result);
-            })
-            .catch(() => {
-                res.status(500);
-                res.end();
-            });
-    });
-});
-
-function startLambdaServer(port) {
     app.listen(port);
 
     debug('Listening on port', port);

--- a/modules/byol/package-lock.json
+++ b/modules/byol/package-lock.json
@@ -103,6 +103,11 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
+		"workerpool": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-5.0.4.tgz",
+			"integrity": "sha512-Sywova24Ow2NQ24JPB68bI89EdqMDjUXo4OpofK/QMD7C2ZVMloYBgQ5J3PChcBJHj2vspsmGx1/3nBKXtUkXQ=="
+		},
 		"yaml-cfn": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/yaml-cfn/-/yaml-cfn-0.2.3.tgz",

--- a/modules/byol/package.json
+++ b/modules/byol/package.json
@@ -14,6 +14,7 @@
 		"path-match": "^1.2.4",
 		"supports-color": "^7.0.0",
 		"uuid": "^3.3.2",
+		"workerpool": "5.0.4",
 		"yaml-cfn": "^0.2.2"
 	}
 }

--- a/modules/byol/src/assets/callHandlerProcess.js
+++ b/modules/byol/src/assets/callHandlerProcess.js
@@ -8,10 +8,7 @@ async function callHandler({
     event,
     environment,
 }) {
-    Object.keys(process.env).forEach((envKey) => delete process.env[envKey]);
-    Object.keys(environment).forEach((envKey) => {
-        process.env[envKey] = environment[envKey];
-    });
+    process.env = environment;
 
     // eslint-disable-next-line import/no-dynamic-require, global-require
     const { [handlerName]: handler } = require(absoluteIndexPath);

--- a/modules/byol/src/assets/callHandlerProcess.js
+++ b/modules/byol/src/assets/callHandlerProcess.js
@@ -1,70 +1,48 @@
+const workerpool = require('workerpool');
+
 const LAMBDA_PAYLOAD_BYTE_SIZE_LIMIT = 6000000;
-let handledResponse = false;
 
-function onHandlerResponse(error, result) {
-    if (handledResponse) {
-        return;
-    }
-
-    handledResponse = true;
-
-    if (error) {
-        process.send({
-            error: {
-                message: error.message,
-                code: error.code,
-            },
-        });
-    } else if (Buffer.byteLength(JSON.stringify(result)) >= LAMBDA_PAYLOAD_BYTE_SIZE_LIMIT) {
-        process.send({
-            error: {
-                message: `Payload size is too large (limit ${LAMBDA_PAYLOAD_BYTE_SIZE_LIMIT})`,
-                code: 'PAYLOAD_TOO_LARGE',
-            },
-        });
-    } else {
-        process.send({ result });
-    }
-}
-
-function callHandler({
+async function callHandler({
     absoluteIndexPath,
     handlerName,
     event,
+    environment,
 }) {
+    Object.keys(process.env).forEach((envKey) => delete process.env[envKey]);
+    Object.keys(environment).forEach((envKey) => {
+        process.env[envKey] = environment[envKey];
+    });
+
     // eslint-disable-next-line import/no-dynamic-require, global-require
     const { [handlerName]: handler } = require(absoluteIndexPath);
 
     if (!handler) {
-        onHandlerResponse(new Error('HANDLER_NOT_FOUND'));
-        return;
+        throw new Error('HANDLER_NOT_FOUND');
     }
 
-    const maybePromise = handler(event, {}, onHandlerResponse);
+    const result = await new Promise(((resolve, reject) => {
+        const maybePromise = handler(event, {}, (err, res) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(res);
+            }
+        });
 
-    if (maybePromise && typeof maybePromise.then === 'function' && typeof maybePromise.catch === 'function') {
-        maybePromise
-            .then((res) => onHandlerResponse(null, res))
-            .catch((err) => onHandlerResponse(err));
+        if (maybePromise && typeof maybePromise.then === 'function' && typeof maybePromise.catch === 'function') {
+            maybePromise
+                .then((res) => resolve(res))
+                .catch((err) => reject(err));
+        }
+    }));
+
+    if (Buffer.byteLength(JSON.stringify(result)) >= LAMBDA_PAYLOAD_BYTE_SIZE_LIMIT) {
+        throw new Error('PAYLOAD_TOO_LARGE');
     }
+
+    return result;
 }
 
-function onMessage(message) {
-    const {
-        type,
-        payload,
-    } = message;
-
-    switch (type) {
-    case 'CALL':
-        callHandler(payload);
-        break;
-    case 'EXIT':
-        process.exit(0);
-        break;
-    default:
-        throw new Error('UNSUPPORTED MESSAGE');
-    }
-}
-
-process.on('message', onMessage);
+workerpool.worker({
+    callHandler,
+});

--- a/modules/byol/src/handlerWorkerPool.js
+++ b/modules/byol/src/handlerWorkerPool.js
@@ -1,8 +1,51 @@
 const path = require('path');
 const workerpool = require('workerpool');
 
-const handlerWorkerPool = workerpool.pool(path.join(__dirname, 'assets', 'callHandlerProcess.js'));
+const workerPoolMap = new Map();
+
+function terminateWorkerPool(handler) {
+    const { pool } = workerPoolMap.get(handler);
+    const terminationPromise = pool.terminate();
+
+    workerPoolMap.delete(handler);
+
+    return terminationPromise;
+}
+
+function terminateWorkerPools() {
+    const terminationPromises = [];
+
+    workerPoolMap.forEach((pool, key) => {
+        terminationPromises.push(terminateWorkerPool(key));
+    });
+
+    return Promise.all(terminationPromises);
+}
+
+async function getWorkerPool(handler, environment = {}) {
+    if (!workerPoolMap.has(handler)) {
+        const pool = workerpool.pool(path.join(__dirname, 'assets', 'callHandlerProcess.js'));
+
+        workerPoolMap.set(handler, {
+            pool,
+            environment,
+        });
+    }
+
+    const { pool, environment: poolEnvironment } = workerPoolMap.get(handler);
+
+    if (JSON.stringify(poolEnvironment) !== JSON.stringify(environment)) {
+        terminateWorkerPool(handler);
+
+        return getWorkerPool(handler, environment);
+    }
+
+    return pool;
+}
+
 
 module.exports = {
-    handlerWorkerPool,
+    getWorkerPool,
+    terminateWorkerPool,
+    terminateWorkerPools,
 };

--- a/modules/byol/src/handlerWorkerPool.js
+++ b/modules/byol/src/handlerWorkerPool.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const workerpool = require('workerpool');
+
+const handlerWorkerPool = workerpool.pool(path.join(__dirname, 'assets', 'callHandlerProcess.js'));
+
+module.exports = {
+    handlerWorkerPool,
+};

--- a/modules/byol/src/invokeApi.js
+++ b/modules/byol/src/invokeApi.js
@@ -153,7 +153,7 @@ async function invokeApi(httpMethod, httpUrl, httpHeaders = [], body, {
         templatePath,
         envPath,
         requestId,
-        keepAlive
+        keepAlive,
     });
 }
 

--- a/modules/byol/src/invokeApi.js
+++ b/modules/byol/src/invokeApi.js
@@ -107,6 +107,7 @@ function parseHeaders(rawHeaders) {
 async function invokeApi(httpMethod, httpUrl, httpHeaders = [], body, {
     templatePath,
     envPath,
+    keepAlive = false,
 } = {}) {
     const parsedUrl = new URL(httpUrl, 'http://localhost');
 
@@ -148,7 +149,12 @@ async function invokeApi(httpMethod, httpUrl, httpHeaders = [], body, {
         requestContext,
         body,
     };
-    return invokeFunction(matchingMapping.functionName, event, { templatePath, envPath, requestId });
+    return invokeFunction(matchingMapping.functionName, event, {
+        templatePath,
+        envPath,
+        requestId,
+        keepAlive
+    });
 }
 
 module.exports = {

--- a/modules/byol/src/invokeFunction.js
+++ b/modules/byol/src/invokeFunction.js
@@ -45,6 +45,7 @@ async function invokeFunction(functionName, event, {
     templatePath = path.join(process.cwd(), 'template.yml'),
     envPath = path.join(process.cwd(), 'env.json'),
     requestId,
+    keepAlive = false,
 } = {}) {
     const debug = getDebug(requestId || generateRequestId());
 
@@ -70,6 +71,7 @@ async function invokeFunction(functionName, event, {
             handlerName,
             environment,
             event,
+            keepAlive,
         });
 
         debug('End');

--- a/modules/byol/src/invokeFunction.spec.js
+++ b/modules/byol/src/invokeFunction.spec.js
@@ -19,7 +19,7 @@ describe('invokeFunction', function () {
     });
 
     after(async function () {
-        await terminateWorkerPools()
+        await terminateWorkerPools();
     });
 
     it('invokes the async function\'s handler', async function () {

--- a/modules/byol/src/invokeFunction.spec.js
+++ b/modules/byol/src/invokeFunction.spec.js
@@ -8,18 +8,18 @@ const {
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { invokeFunction } = require('./invokeFunction');
-const { handlerWorkerPool } = require('./handlerWorkerPool');
+const { terminateWorkerPools } = require('./handlerWorkerPool');
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('invokeFunction', function () {
     before(async function () {
-        await handlerWorkerPool.terminate();
+        await terminateWorkerPools();
     });
 
     after(async function () {
-        await handlerWorkerPool.terminate();
+        await terminateWorkerPools()
     });
 
     it('invokes the async function\'s handler', async function () {

--- a/modules/byol/src/invokeFunction.spec.js
+++ b/modules/byol/src/invokeFunction.spec.js
@@ -1,13 +1,27 @@
 const path = require('path');
-const { describe, it } = require('mocha');
+const {
+    describe,
+    it,
+    before,
+    after,
+} = require('mocha');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { invokeFunction } = require('./invokeFunction');
+const { handlerWorkerPool } = require('./handlerWorkerPool');
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('invokeFunction', function () {
+    before(async function () {
+        await handlerWorkerPool.terminate();
+    });
+
+    after(async function () {
+        await handlerWorkerPool.terminate();
+    });
+
     it('invokes the async function\'s handler', async function () {
         const templatePath = path.resolve(__dirname, '../tests/assets/template.yml');
         const event = {
@@ -59,7 +73,7 @@ describe('invokeFunction', function () {
         expect(result).to.have.property('args');
 
         const { args } = result;
-        expect(args).to.be.an('array').with.length(3);
+        expect(args).to.be.an('array').with.length(2);
         expect(args[0]).to.deep.equal(event);
     });
 
@@ -122,7 +136,7 @@ describe('invokeFunction', function () {
             { templatePath },
         );
 
-        await expect(invokePromise).to.eventually.be.rejectedWith('FORK_EXITED_UNEXPECTEDLY');
+        await expect(invokePromise).to.eventually.be.rejectedWith('ERROR');
     });
 
     it('rejects when the function can\'t be found', async function () {

--- a/modules/byol/src/invokeHandler.js
+++ b/modules/byol/src/invokeHandler.js
@@ -1,22 +1,29 @@
-const { getWorkerPool } = require('./handlerWorkerPool');
+const { getWorkerPool, terminateWorkerPool } = require('./handlerWorkerPool');
 
 async function invokeHandler({
     absoluteIndexPath,
     handlerName,
     environment,
     event,
+    keepAlive = false,
 }) {
     const workerPool = await getWorkerPool(handlerName, environment);
 
-    return await workerPool.exec('callHandler', [{
-        absoluteIndexPath,
-        handlerName,
-        event,
-        environment: {
-            ...process.env,
-            ...environment,
-        },
-    }]);
+    try {
+        return await workerPool.exec('callHandler', [{
+            absoluteIndexPath,
+            handlerName,
+            event,
+            environment: {
+                ...process.env,
+                ...environment,
+            },
+        }]);
+    } finally {
+        if (!keepAlive) {
+            terminateWorkerPool(handlerName);
+        }
+    }
 }
 
 module.exports = {

--- a/modules/byol/src/invokeHandler.js
+++ b/modules/byol/src/invokeHandler.js
@@ -1,4 +1,4 @@
-const { handlerWorkerPool } = require('./handlerWorkerPool');
+const { getWorkerPool } = require('./handlerWorkerPool');
 
 async function invokeHandler({
     absoluteIndexPath,
@@ -6,7 +6,9 @@ async function invokeHandler({
     environment,
     event,
 }) {
-    return handlerWorkerPool.exec('callHandler', [{
+    const workerPool = await getWorkerPool(handlerName, environment);
+
+    return await workerPool.exec('callHandler', [{
         absoluteIndexPath,
         handlerName,
         event,

--- a/modules/byol/src/invokeHandler.spec.js
+++ b/modules/byol/src/invokeHandler.spec.js
@@ -8,18 +8,18 @@ const {
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { invokeHandler } = require('./invokeHandler');
-const { handlerWorkerPool } = require('./handlerWorkerPool');
+const { terminateWorkerPools } = require('./handlerWorkerPool');
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('invokeHandler', function () {
     before(async function () {
-        await handlerWorkerPool.terminate();
+        await terminateWorkerPools();
     });
 
     after(async function () {
-        await handlerWorkerPool.terminate();
+        await terminateWorkerPools();
     });
 
     it('invokes an async handler', async function () {

--- a/modules/byol/src/invokeHandler.spec.js
+++ b/modules/byol/src/invokeHandler.spec.js
@@ -1,13 +1,27 @@
 const path = require('path');
-const { describe, it } = require('mocha');
+const {
+    describe,
+    it,
+    before,
+    after,
+} = require('mocha');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { invokeHandler } = require('./invokeHandler');
+const { handlerWorkerPool } = require('./handlerWorkerPool');
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
 describe('invokeHandler', function () {
+    before(async function () {
+        await handlerWorkerPool.terminate();
+    });
+
+    after(async function () {
+        await handlerWorkerPool.terminate();
+    });
+
     it('invokes an async handler', async function () {
         const absoluteIndexPath = path.resolve(__dirname, '../tests/assets/goodHandler.js');
 
@@ -51,7 +65,7 @@ describe('invokeHandler', function () {
         expect(result).to.have.property('args');
 
         const { args } = result;
-        expect(args).to.be.an('array').with.length(3);
+        expect(args).to.be.an('array').with.length(2);
         expect(args[0]).to.deep.equal(event);
     });
 
@@ -111,7 +125,7 @@ describe('invokeHandler', function () {
             event: { message: errorMessage },
         });
 
-        await expect(invokePromise).to.eventually.be.rejectedWith('FORK_EXITED_UNEXPECTEDLY');
+        await expect(invokePromise).to.eventually.be.rejectedWith('ERROR');
     });
 
     it('rejects when the handler function can\'t be found', async function () {

--- a/modules/byol/tests/assets/goodCallbackHandler.js
+++ b/modules/byol/tests/assets/goodCallbackHandler.js
@@ -1,11 +1,9 @@
 const { env } = process;
 
-async function handler(...args) {
-    const callback = args[args.length - 1];
-
+async function handler(event, context, callback) {
     callback(null, {
-        args,
-        env,
+        args: [event, context],
+        env: { ...env },
     });
 }
 

--- a/modules/byol/tests/assets/goodHandler.js
+++ b/modules/byol/tests/assets/goodHandler.js
@@ -1,9 +1,9 @@
 const { env } = process;
 
-async function handler(...args) {
+async function handler(event, context) {
     return {
-        args,
-        env,
+        args: [event, context],
+        env: { ...env },
     };
 }
 


### PR DESCRIPTION
This more closely mimics the lambda environment where the process is kept alive between invokes which makes invokes after the initial invoke much faster. `workerpool` will also use worker threads if available to further speed things up. This'll also result in a performance boost when not using long-lived workers.

~One thing I'm slightly worried about is side effects in functions when multiple functions are called in the same byol instance. That should be an easy fix if that proves to be a problem. Maybe this should be a breaking change?~

Since handlers would essentially be cached this would prevent changes from showing up until byol is restarted. Since that's not something you'd want during development I guess I should make this an option.