### PR TITLE
fix(byol-cli): crash when receiving websocket message

### DIFF
--- a/modules/byol-cli/src/lib/registerWebsocketListeners.js
+++ b/modules/byol-cli/src/lib/registerWebsocketListeners.js
@@ -189,7 +189,7 @@ function onMessage({
 
         const event = {
             requestContext: getRequestContext(route, connectionContext, apiInfo, EVENT_TYPE.MESSAGE),
-            body: message,
+            body: message.toString(),
             isBase64Encoded: false,
         };
 
@@ -198,7 +198,7 @@ function onMessage({
             .then((result) => {
                 const statusCode = result.result.statusCode || 500;
                 if (statusCode < 200 || statusCode >= 400) {
-                    logCaughtError(ws, connectionContext, result.result);
+                    logCaughtError(route, connectionContext, result.result);
                     terminateConnection(ws, connectionContext, websocketConnections);
                 } else {
                     const routeKey = route.route.Properties.RouteKey;


### PR DESCRIPTION
- send route config instead of websocket to error handler
- transform received message to string before sending to lambda handler