### PR TITLE
fix(byol-cli): do not stringify body of lambda result

### DIFF
--- a/modules/byol-cli/src/lib/registerWebsocketListeners.js
+++ b/modules/byol-cli/src/lib/registerWebsocketListeners.js
@@ -203,7 +203,7 @@ function onMessage({
                 } else {
                     const routeKey = route.route.Properties.RouteKey;
                     verbose(`route: ${routeKey} for ${connectionContext.connectionId} with result: %o`, result);
-                    ws.send(JSON.stringify(result.result.body));
+                    ws.send(result.result.body);
                 }
             })
             .catch((err) => {


### PR DESCRIPTION
This is not necessary since the result.body of a lambda is already a string.
The extra stringify caused characters to get escaped twice making the receiver of the message unable to JSON.parse it