### PR TITLE
fix(byol-cli): mismatch between amazon and local api

### DIFF
--- a/modules/byol-cli/src/lib/createHttpServer.js
+++ b/modules/byol-cli/src/lib/createHttpServer.js
@@ -6,6 +6,8 @@ let server = {};
 function createHttpServer(debug, port) {
     if (!server.app && !server.listen) {
         const app = express();
+        app.set('x-powered-by', false);
+        app.set('etag', false);
         app.use(cors());
         app.set('trust proxy', true);
         const listen = app.listen(port);

--- a/modules/byol-cli/src/lib/registerWebsocketApi.js
+++ b/modules/byol-cli/src/lib/registerWebsocketApi.js
@@ -20,7 +20,7 @@ function registerWebSocketAPI(websocketConnections, apiInfo, { port = 3000 }) {
     const wsNotFound = (res) => {
         setHeaders(res);
         res.set('x-amzn-ErrorType', 'GoneException');
-        res.sendStatus(410);
+        res.status(410).end();
     };
     const getRoute = escapeRoute(`/${apiInfo.stage}/@connections/:id`);
     logRegisteredHTTPRoute('GET', getRoute);
@@ -29,13 +29,16 @@ function registerWebSocketAPI(websocketConnections, apiInfo, { port = 3000 }) {
         if (websocketConnections.has(id)) {
             const { context } = websocketConnections.get(id);
             setHeaders(res);
-            res.send({
-                ConnectedAt: new Date(context.connectedAt).toISOString(),
-                Identity: {
-                    SourceIp: context.ip,
-                },
-                LastActiveAt: new Date(context.lastActiveAt).toISOString(),
-            });
+            res
+                .status(200)
+                .send({
+                    ConnectedAt: new Date(context.connectedAt).toISOString(),
+                    Identity: {
+                        SourceIp: context.ip,
+                    },
+                    LastActiveAt: new Date(context.lastActiveAt).toISOString(),
+                })
+                .end();
         } else {
             wsNotFound(res);
         }
@@ -55,7 +58,7 @@ function registerWebSocketAPI(websocketConnections, apiInfo, { port = 3000 }) {
                 const { ws } = websocketConnections.get(id);
                 ws.send(body);
                 setHeaders(res);
-                res.sendStatus(200);
+                res.status(200).end();
             } else {
                 wsNotFound(res);
             }
@@ -70,7 +73,7 @@ function registerWebSocketAPI(websocketConnections, apiInfo, { port = 3000 }) {
             const { ws } = websocketConnections.get(id);
             ws.close();
             setHeaders(res);
-            res.sendStatus(204);
+            res.status(204).end();
         } else {
             wsNotFound(res);
         }

--- a/modules/byol-cli/src/lib/registerWebsocketApi.js
+++ b/modules/byol-cli/src/lib/registerWebsocketApi.js
@@ -16,6 +16,8 @@ function registerWebSocketAPI(websocketConnections, apiInfo, { port = 3000 }) {
     const setHeaders = (res) => {
         res.set('x-amzn-RequestId', generateRequestId());
         res.set('x-amz-apigw-id', apiInfo.apiId);
+        res.set('X-Amzn-Trace-Id', 'Root=1-6107c109-306f421006007da9658753b3');
+        res.set('Content-type', 'application/json');
     };
     const wsNotFound = (res) => {
         setHeaders(res);


### PR DESCRIPTION
There were a few mismatches between the local and amazon API responses.
We returned an 'OK' in the body for 200 responses, and we returned incorrect or were missing headers.
