### PR TITLE
chore: specify node and npm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.0",
   "description": "Bring Your Own Lambda",
   "license": "MIT",
+  "engines": {
+    "node": ">=14",
+    "npm": "^6.0.0"
+  },
   "scripts": {
     "cli": "node modules/byol-cli/src/index.js",
     "lint": "npm run eslint",


### PR DESCRIPTION
Should help Renovate use the "right" npm version in https://github.com/Swydo/byol/pull/378.
