### PR TITLE
fix(byol-cli): close websocket connection 10 minutes after incoming message

### DIFF
--- a/modules/byol-cli/src/lib/registerWebsocketListeners.js
+++ b/modules/byol-cli/src/lib/registerWebsocketListeners.js
@@ -194,7 +194,7 @@ function onMessage({
         clearTimeout(context.disconnectTimeout);
         context.disconnectTimeout = setTimeout(() => {
             closeConnection(ws, connectionContext, websocketConnections);
-        }, 30000);
+        }, 10 * 60 * 1000);
 
         const event = {
             requestContext: getRequestContext(route, connectionContext, apiInfo, EVENT_TYPE.MESSAGE),


### PR DESCRIPTION
Closing the websocket connection 30 seconds after an incoming message is too early. Changed it to 10 minutes, the same as the initial timeout.