### PR TITLE
feat: add getRemainingTimeInMillis

### DIFF
--- a/modules/byol/src/assets/callHandlerProcess.js
+++ b/modules/byol/src/assets/callHandlerProcess.js
@@ -82,6 +82,9 @@ async function callHandler({
     const { [handlerName]: handler } = await import(absoluteIndexPath);
     const awsContext = {
         awsRequestId: generateRequestId(),
+        getRemainingTimeInMillis() {
+            return 365 * 24 * 60 * 60 * 1000;
+        }
     };
 
     if (!handler) {


### PR DESCRIPTION
Adding the getRemainingTimeInMillis function to the aws context. I've opted to return 1 year in milliseconds as a constant since we don't have a time limit on these lambdas and I find it hard to believe that a lambda runs for that long. 

I first tried returning `Number.MAX_SAFE_INTEGER` since it's technically correct but it actually makes using the return value difficult. Can't use the millis in things like DateTime option since they overflow/turn into NaNs.