### PR TITLE
fix: remove setting "default" profile by default

### DIFF
--- a/modules/byol-cli/src/commands/invoke/index.js
+++ b/modules/byol-cli/src/commands/invoke/index.js
@@ -18,9 +18,7 @@ const builder = (yargs) => yargs
     .option('inspect-port', {
         default: 43210, // Default in workerpool.
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('template-path', {
         alias: ['template-file', 'template', 't'],

--- a/modules/byol-cli/src/commands/start/index.js
+++ b/modules/byol-cli/src/commands/start/index.js
@@ -20,9 +20,7 @@ const builder = (yargs) => yargs
         alias: 'p',
         default: 3000,
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('sqs-endpoint-url', {
         type: 'string',

--- a/modules/byol-cli/src/commands/startApi.js/index.js
+++ b/modules/byol-cli/src/commands/startApi.js/index.js
@@ -20,9 +20,7 @@ const builder = (yargs) => yargs
         alias: 'p',
         default: 3000,
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('sqs-endpoint-url', {
         type: 'string',

--- a/modules/byol-cli/src/commands/startLambda/index.js
+++ b/modules/byol-cli/src/commands/startLambda/index.js
@@ -20,9 +20,7 @@ const builder = (yargs) => yargs
         alias: 'p',
         default: 3000,
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('sqs-endpoint-url', {
         type: 'string',

--- a/modules/byol-cli/src/commands/startSqs/index.js
+++ b/modules/byol-cli/src/commands/startSqs/index.js
@@ -20,9 +20,7 @@ const builder = (yargs) => yargs
         alias: 'p',
         default: 3000,
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('sqs-endpoint-url', {
         type: 'string',

--- a/modules/byol-cli/src/commands/startWebsocket/index.js
+++ b/modules/byol-cli/src/commands/startWebsocket/index.js
@@ -14,9 +14,7 @@ const builder = (yargs) => yargs
         alias: 'p',
         default: 3000,
     })
-    .option('profile', {
-        default: 'default',
-    })
+    .option('profile')
     .option('region')
     .option('template-path', {
         alias: ['template-file', 'template', 't'],

--- a/modules/byol/src/invokeFunction.js
+++ b/modules/byol/src/invokeFunction.js
@@ -32,10 +32,17 @@ function getFunctionEnvironment(envPath, functionName) {
 }
 
 function getAwsEnvironment({ profile, region }) {
-    return {
-        AWS_PROFILE: profile,
-        AWS_REGION: region,
-    };
+    const awsEnvironment = {};
+
+    if (region) {
+        awsEnvironment.AWS_REGION = region;
+    }
+
+    if (profile) {
+        awsEnvironment.AWS_PROFILE = profile;
+    }
+
+    return awsEnvironment;
 }
 
 async function invokeFunction(functionName, event, {
@@ -45,7 +52,7 @@ async function invokeFunction(functionName, event, {
     region,
     requestId,
     keepAlive = false,
-    profile = 'default',
+    profile,
     invocationType = 'RequestResponse',
 } = {}) {
     const resource = getFunctionResource(templatePath, functionName);


### PR DESCRIPTION
AWS SDK v3 has a different opinion regarding credentials when `AWS_PROFILE` is set. In V2 it would first look at credentials in the environment directly, then fall back to credentials from the profile. In V3 it will first check the profile if `AWS_PROFILE` is set.

Because Byol sets the `AWS_PROFILE` environment variable by default there is no way to directly pass credentials in the environment, except when `AWS_PROFILE` is explicitly unset (for instance by passing an empty string).

Removing this default value is a breaking change.